### PR TITLE
リファクタリング、修正

### DIFF
--- a/database_manager.py
+++ b/database_manager.py
@@ -14,6 +14,9 @@ class DatabaseManager:
     """
     def __init__(self, conf, sqlfile):
         """コンストラクタ
+            Args:
+                conf:外部設定ファイル
+                sqlfile:実行SQLクエリファイル
         """
         self.connection = MySQLdb.connect(host="localhost",port=3306,
                                           user=conf.user,
@@ -26,6 +29,8 @@ class DatabaseManager:
 
     def exec_select(self, *args):
         """SELECT実行メソッド
+            Args:
+                args:SQLパラメータ
             Return:
                 実行結果
         """
@@ -38,6 +43,8 @@ class DatabaseManager:
 
     def exec_query(self, *args):
         """INSERT/UPDATE/DELETE実行メソッド
+            Args:
+                args:SQLパラメータ
             Return:
                 処理件数
         """

--- a/logger_utils.py
+++ b/logger_utils.py
@@ -13,6 +13,8 @@ class Logger:
     """
     def __init__(self, config):
         """コンストラクタ
+            Args:
+                config:外部設定ファイル
         """
         self.save_dir = config.file_save_dir
         self.log_file_nm_base = config.file_nm_base


### PR DESCRIPTION
URLを含むmentionの場合は生成文による回答を行わないよう修正。
　URLと質問文を適切に整形することが煩雑な上、URLのリンク先の内容を理解することはないため。
外部設定ファイルに記載した許可サーバーのみに返答する処理が機能していなかったため、修正。
　正規表現にてマッチするか否かで許可サーバーかを判定。